### PR TITLE
Add comparison table for opportunity types

### DIFF
--- a/docs/opportunities.md
+++ b/docs/opportunities.md
@@ -24,7 +24,7 @@ This comparison table presents a quick overview of the different opportunity typ
 | **Compensation**    | Fixed reward (one-time payout)         | Milestone-based payments or revenue share | Recurring stipend, grants, or resource allocation |
 | **Ownership**       | Task ownership remains with poster     | Shared ownership (contributors may retain partial rights) | Sponsored party retains full ownership |
 | **Application**     | Open submission (anyone can complete)  | Proposal-based (team/plan required)    | Formal proposal (goals, budget, KPIs)  |
-| **Winner Elegibility**     | Multiple winners                | Only one winner                        | Multiple winners      |
+| **Winner Eligibility**     | Multiple winners                | Only one winner                        | Multiple winners      |
 | **Best For**        | Quick wins, micro-tasks, freelancers   | Builders, startups, collaborative teams | DAOs, long-term contributors, community leaders |
 | **Accountability**  | Proof of completion required           | Milestone reviews & deliverables       | Periodic reporting (transparency expected) |
 | **Flexibility**     | Rigid (fixed requirements)             | Adaptable (scope may evolve)           | Highly flexible (funding can shift with needs) |

--- a/docs/opportunities.md
+++ b/docs/opportunities.md
@@ -10,6 +10,31 @@ description: NEARN opportunities
 - [Projects](#projects): Hire a Freelancer
 - [Sponsorships](#sponsorships): Support Contributors
 
+## Overview
+
+This comparison table presents a quick overview of the different opportunity types, highlighting the key differences between bounties, projects, and sponsorships:
+
+|               | Bounty                                  | Project                                | Sponsorship                            |
+|-----------------------|----------------------------------------|----------------------------------------|----------------------------------------|
+| **Purpose**          | Short-term tasks for quick contributions | Long-term collaborative initiatives   | Sustained funding/support for initiatives or teams |
+| **Duration**         | Days to weeks                          | Weeks to months                        | Ongoing (often months or longer)       |
+| **Team Size**        | Individual or very small groups        | Small to medium teams                  | Any size (individuals to organizations)|
+| **Scope**           | Narrow, well-defined tasks             | Broader objectives with milestones    | Open-ended support for initiatives    |
+| **Compensation**    | Fixed reward (one-time payout)         | Milestone-based payments or revenue share | Recurring stipend, grants, or resource allocation |
+| **Ownership**       | Task ownership remains with poster     | Shared ownership (contributors may retain partial rights) | Sponsored party retains full ownership |
+| **Application**     | Open submission (anyone can complete)  | Proposal-based (team/plan required)    | Formal proposal (goals, budget, KPIs)  |
+| **Best For**        | Quick wins, micro-tasks, freelancers   | Builders, startups, collaborative teams | DAOs, long-term contributors, community leaders |
+| **Accountability**  | Proof of completion required           | Milestone reviews & deliverables       | Periodic reporting (transparency expected) |
+| **Flexibility**     | Rigid (fixed requirements)             | Adaptable (scope may evolve)           | Highly flexible (funding can shift with needs) |
+| **Community Impact** | Solves immediate needs                 | Creates reusable tools/products        | Sustains ecosystems (education, infrastructure) |
+| **Example**         | Fixing a bug, creating content         | Developing a new protocol feature      | Funding a community education program |
+
+:::tip Key differences
+- Bounties are transactional (task→reward), while projects and sponsorships are relational
+- Projects emphasize collaboration, while sponsorships emphasize support
+- Bounties have the clearest success criteria, while sponsorships are most flexible
+:::
+
 ## Bounties
 
 Bounties are listings where everyone completes a given scope of work, and competes for the prize pool.

--- a/docs/opportunities.md
+++ b/docs/opportunities.md
@@ -18,11 +18,13 @@ This comparison table presents a quick overview of the different opportunity typ
 |-----------------------|----------------------------------------|----------------------------------------|----------------------------------------|
 | **Purpose**          | Short-term tasks for quick contributions | Long-term collaborative initiatives   | Sustained funding/support for initiatives or teams |
 | **Duration**         | Days to weeks                          | Weeks to months                        | Ongoing (often months or longer)       |
+| **Visibility**         | Public, private, or geo-limited      | Public, private, or geo-limited        | Public, private, or geo-limited        |
 | **Team Size**        | Individual or very small groups        | Small to medium teams                  | Any size (individuals to organizations)|
 | **Scope**           | Narrow, well-defined tasks             | Broader objectives with milestones    | Open-ended support for initiatives    |
 | **Compensation**    | Fixed reward (one-time payout)         | Milestone-based payments or revenue share | Recurring stipend, grants, or resource allocation |
 | **Ownership**       | Task ownership remains with poster     | Shared ownership (contributors may retain partial rights) | Sponsored party retains full ownership |
 | **Application**     | Open submission (anyone can complete)  | Proposal-based (team/plan required)    | Formal proposal (goals, budget, KPIs)  |
+| **Winner Elegibility**     | Multiple winners                | Only one winner                        | Multiple winners      |
 | **Best For**        | Quick wins, micro-tasks, freelancers   | Builders, startups, collaborative teams | DAOs, long-term contributors, community leaders |
 | **Accountability**  | Proof of completion required           | Milestone reviews & deliverables       | Periodic reporting (transparency expected) |
 | **Flexibility**     | Rigid (fixed requirements)             | Adaptable (scope may evolve)           | Highly flexible (funding can shift with needs) |

--- a/docs/opportunities.md
+++ b/docs/opportunities.md
@@ -43,6 +43,8 @@ Bounties are listings where everyone completes a given scope of work, and compet
 
 - Bounties can have multiple winners with prize distributions
 
+- Contributors are allowed only one submission per bounty
+
 - Great for awareness campaigns where you want to reach the most people possible
 
 - Get multiple options to choose from
@@ -59,6 +61,8 @@ Projects are freelance gigs — people apply with their proposals but don’t be
 
 - Projects can only have one winner
 
+- Contributors are allowed only one submission per project
+
 - Perfect for work that requires collaboration and iteration
 
 - Single output that is specific to your exact needs
@@ -74,6 +78,8 @@ Get applications based on a questionnaire set by you, and select one applicant t
 Sponsorship listings empower you to fund and reward individual contributions by directly sponsoring innovators.
 
 - Sponsorships can support multiple people (non-competitively)
+
+- Contributors are allowed multiple submissions (each submission is allowed only after approve/reject)
 
 - Ideal for initiatives fueling targeted support and growth
 


### PR DESCRIPTION
Introduced an overview section with a comparison table highlighting key differences between bounties, projects, and sponsorships. Added a tip summarizing the main distinctions to help users quickly understand each opportunity type.